### PR TITLE
Martin and Josh

### DIFF
--- a/linear_algebra/CMakeLists.txt
+++ b/linear_algebra/CMakeLists.txt
@@ -40,6 +40,7 @@ add_executable(test_average_fortran test_average_fortran.F90)
 target_link_libraries(test_average_fortran OpenMP::OpenMP_Fortran)
 
 add_executable(test_integrate test_integrate.c)
+target_link_libraries(test_integrate OpenMP::OpenMP_C)
 
 add_executable(test_openmp test_openmp.c)
 target_link_libraries(test_openmp OpenMP::OpenMP_C)
@@ -48,4 +49,3 @@ add_test(test_vector_dot test_vector_dot)
 add_test(test_vector_add test_vector_add)
 add_test(test_matrix_vector_mul test_matrix_vector_mul)
 add_test(test_matrix_matrix_mul test_matrix_matrix_mul)
-

--- a/linear_algebra/test_integrate.c
+++ b/linear_algebra/test_integrate.c
@@ -1,6 +1,9 @@
-
+#include <omp.h>
 #include <stdio.h>
 #include <math.h>
+
+
+#include "linear_algebra.h"
 
 static double
 f(double x)
@@ -11,16 +14,30 @@ f(double x)
 int
 main(int argc, char **argv)
 {
+  double t_beg = Wtime();
+
+
   const int N = 1000;
   double dx = 1. / N;
 
   double sum = 0.;
-  for (int i = 0; i < N; i++) {
-    double x0 = i * dx;
-    double x1 = (i+1) * dx;
-    sum += .5 * (f(x0) + f(x1)) * dx;
+  #pragma omp parallel
+  {
+    double local_sum=0;
+#pragma omp for
+    for (int i = 0; i < N; i++) {
+      double x0 = i * dx;
+      double x1 = (i+1) * dx;
+      sum += .5 * (f(x0) + f(x1)) * dx;
+    }
+    sum += local_sum;
+    printf("Thread %d END Time: %lf,  sum = %g\n", omp_get_thread_num(), Wtime(), sum);
   }
-  printf("sum = %g\n", sum);
+  double t_end = Wtime();
+
+  //if(sum < 0.7853) {
+    //printf("Time: %f,  sum = %g\n", t_end-t_beg, sum);
+  //}
 
   return 0;
 }

--- a/linear_algebra/test_integrate.c
+++ b/linear_algebra/test_integrate.c
@@ -27,7 +27,7 @@ main(int argc, char **argv)
       double x0 = i * dx;
       double x1 = (i+1) * dx;
       double val = .5 * (f(x0) + f(x1)) * dx;
-#pragma omp critical
+#pragma omp atomic
       sum += val;
     }
     //sum += local_sum;

--- a/linear_algebra/test_integrate.c
+++ b/linear_algebra/test_integrate.c
@@ -21,22 +21,22 @@ main(int argc, char **argv)
   double dx = 1. / N;
 
   double sum = 0.;
-  #pragma omp parallel
-  {
-    double local_sum=0;
-#pragma omp for
+//    double local_sum=0;
+#pragma omp parallel for
     for (int i = 0; i < N; i++) {
       double x0 = i * dx;
       double x1 = (i+1) * dx;
-      sum += .5 * (f(x0) + f(x1)) * dx;
+      double val = .5 * (f(x0) + f(x1)) * dx;
+#pragma omp critical
+      sum += val;
     }
-    sum += local_sum;
-    printf("Thread %d END Time: %lf,  sum = %g\n", omp_get_thread_num(), Wtime(), sum);
-  }
+    //sum += local_sum;
+    //printf("Thread %d END Time: %lf,  sum = %g\n", omp_get_thread_num(), Wtime(), sum);
+
   double t_end = Wtime();
 
   //if(sum < 0.7853) {
-    //printf("Time: %f,  sum = %g\n", t_end-t_beg, sum);
+  printf("Time: %f,  sum = %g\n", t_end-t_beg, sum);
   //}
 
   return 0;

--- a/linear_algebra/test_openmp.c
+++ b/linear_algebra/test_openmp.c
@@ -8,7 +8,18 @@
 int
 main(int argc, char **argv)
 {
+  //single-threaded
+  printf("Hi, just starting.\n");
+  //start running multiple threads
 #pragma omp parallel
-  printf("Hi, I'm thread %d of %d\n", omp_get_thread_num(), omp_get_num_threads());
+  {
+    int thread_id = omp_get_thread_num();
+    int n_threads = omp_get_num_threads();
+    printf("Hi, I'm thread %d of %d\n", thread_id, n_threads);
+
+  }
+
+
+  printf("almost done\n");
   return 0;
 }

--- a/linear_algebra/test_openmp.c
+++ b/linear_algebra/test_openmp.c
@@ -11,13 +11,19 @@ main(int argc, char **argv)
   //single-threaded
   printf("Hi, just starting.\n");
   //start running multiple threads
-#pragma omp parallel
+
+  int test = -1;
+//#pragma omp parallel
+#pragma omp parallel private(test)
   {
+    //test=500;
     int thread_id = omp_get_thread_num();
     int n_threads = omp_get_num_threads();
-    printf("Hi, I'm thread %d of %d\n", thread_id, n_threads);
-
+    //printf("Hi, I'm thread %d of %d\n", thread_id, n_threads);
+    printf("Hello %d/%d test=%d\n", thread_id, n_threads, test);
+    test = thread_id;
   }
+  printf("test = %d\n", test);
 
 
   printf("almost done\n");

--- a/linear_algebra/test_openmp.c
+++ b/linear_algebra/test_openmp.c
@@ -5,27 +5,27 @@
 // ----------------------------------------------------------------------
 // main
 
+
 int
 main(int argc, char **argv)
 {
-  //single-threaded
+  // single-threaded
   printf("Hi, just starting.\n");
-  //start running multiple threads
 
-  int test = -1;
-//#pragma omp parallel
-#pragma omp parallel private(test)
+  int sum = 0;
+  int num_threads;
+
+  // start running multiple threads
+#pragma omp parallel reduction(+:sum)
   {
-    //test=500;
     int thread_id = omp_get_thread_num();
-    int n_threads = omp_get_num_threads();
-    //printf("Hi, I'm thread %d of %d\n", thread_id, n_threads);
-    printf("Hello %d/%d test=%d\n", thread_id, n_threads, test);
-    test = thread_id;
+    num_threads = omp_get_num_threads();
+    printf("My number is %d\n", thread_id);
+    sum = thread_id;
   }
-  printf("test = %d\n", test);
+  // back to single-threaded
+  printf("The sum across all threads is %d, expected: %d\n",
+	 sum, num_threads * (num_threads - 1) / 2);
 
-
-  printf("almost done\n");
   return 0;
 }


### PR DESCRIPTION
**_Assignment done by Martin Ledoux and Josh Simmons_**

_Does the behavior change with optimization enabled? If so, what might be the reason?_
Yes, test for all threads gets initialized to 0

Tested the following Race condition checks with repeated runs of the program:
  for i in {1..100};  do ./test_integrate ; done


**First attempt to avoid the race condition**
commit: 76013cc381076309ac3f05abe0f1d9f9ab7120e0
_Does this code work right? Is it correct? How's the performance?_
It SEEMS to work, but as pointed out in class, it doesn't always work because sum is still a shared variable.
The workload of adding up local_sum variables for each thread is long enough that when each thread completes, they might not step on eachother's sum values before doing the += summation, however, it could happen that two threads complete simultaneously.


**Critical sections**
Commit:  04df2a65a6afcdac3a9092c5367b20bbd281ec41
This seemed to provide high accuracy:
The sum variable is still technically shared, but the critical section locks the variable so that only one thread can write to it at a time, once a previous thread has completed it's summation.


**Atomic Operations**
Commit:  dc30be23dcfd6bf7cbab621bb4619ec96c7b86aa
This provided the same accuracy as the critcal sections, however, it was approximately 4 to 5 time faster.
Again, the atomic section is locking the shared sum variables


**Reductions**:
Commit: 27967796ee22943e924e2d6818ca52683930d602
Modified test_openmp.c for this
Gauss's sum - offset by 1 to account for the fact that thread ids start at 0 (and end at n-1)
Everything works as expected, a series of "My number is ?" with the 8 thread ids, followed by:
"The sum across all threads is 28, expected: 28"
